### PR TITLE
fix: fixed origin mismatch (closes #5)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,14 +1,3 @@
-exports.originalOrigin = function(req, options) {
-  options = options || {};
-  var app = req.app;
-  if (app && app.get && app.get('trust proxy')) {
-    options.proxy = true;
-  }
-  var trustProxy = options.proxy;
-  
-  var proto = (req.headers['x-forwarded-proto'] || '').toLowerCase()
-    , tls = req.connection.encrypted || (trustProxy && 'https' == proto.split(/\s*,\s*/)[0])
-    , host = (trustProxy && req.headers['x-forwarded-host']) || req.headers.host
-    , protocol = tls ? 'https' : 'http';
-  return protocol + '://' + host;
+exports.originalOrigin = function(req) {
+  return req.origin || req.get('origin');
 };


### PR DESCRIPTION
This closes #5 and supports both Koa and Express.