### PR TITLE
Adding support for Android origins

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -59,10 +59,32 @@ Strategy.prototype.authenticate = function(req, options) {
     ctx = ctx || {};
   
     // Verify that the origin contained in client data matches the origin of this
-    // app (which is the relying party).
+    // app (which is the relying party) or the register Android origins.
+    // This supports multiple Android origins as multiple applications could be
+    // connected to the server.
+    // The origins need to be defined like so:
+    // app.set('apk-key-hash', [*PUT HASHES HERE*])
     var origin = utils.originalOrigin(req);
-    if (origin !== clientData.origin) {
-      return self.fail({ message: 'Origin mismatch' }, 403);
+    if (clientData.origin.startsWith('android:')) {
+      if (req.app && req.app.get && req.app.get('apk-key-hash')) {
+        var found = false
+        var hashes = req.app.get('apk-key-hash')
+        for (hash of hashes) {
+          hash = 'android:apk-key-hash:' + hash 
+          if (hash === clientData.origin) {
+            found = true
+          }
+        }
+        if (!found) {
+          return self.fail({ message: 'Origin mismatch' }, 403);
+        }
+      } else {
+        return self.fail({ message: 'Origin mismatch' }, 404);
+      }
+    } else {
+      if (origin !== clientData.origin) {
+        return self.fail({ message: 'Origin mismatch' }, 403);
+      }
     }
   
     // TODO: Verify the state of Token Binding for the TLS connection over which


### PR DESCRIPTION
This proposition adds the support for the origins sent by Android applications in their client data.

The origins for the applications must be declared like so:
`app.set('apk-key-hash', [*PUT HASHES HERE*])`